### PR TITLE
Raise error when configuration is missing

### DIFF
--- a/lib/claim_token/decryptor.rb
+++ b/lib/claim_token/decryptor.rb
@@ -39,6 +39,7 @@ module ClaimToken
     end
 
     def encryption_key
+      raise "MissingKeyException : ClaimToken configuration is missing the shared_encryption_key" unless ClaimToken.configuration.shared_encryption_key.present?
       ClaimToken.configuration.shared_encryption_key
     end
 

--- a/lib/claim_token/encryptor.rb
+++ b/lib/claim_token/encryptor.rb
@@ -37,10 +37,12 @@ module ClaimToken
     end
 
     def cipher_type
+      raise "MissingKeyException : ClaimToken configuration is missing the cipher_type" unless ClaimToken.configuration.cipher_type.present?
       ClaimToken.configuration.cipher_type
     end
 
     def encryption_key
+      raise "MissingKeyException : ClaimToken configuration is missing the shared_encryption_key" unless ClaimToken.configuration.shared_encryption_key.present?
       ClaimToken.configuration.shared_encryption_key
     end
 


### PR DESCRIPTION
When running the "new" , now default Phoenix, I would be missing both claim token keys required on config but I would not receive any meaningful error message. I've changed that so that we now know what is going wrong